### PR TITLE
(#13) fix filtering on event type

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -50,3 +50,8 @@ func (e *basicEvent) String() string {
 func (e *basicEvent) Type() Type {
 	return e.dtype
 }
+
+// TypeString the string representation of the event type
+func (e *basicEvent) TypeString() string {
+	return e.etype
+}

--- a/basic_test.go
+++ b/basic_test.go
@@ -57,4 +57,11 @@ var _ = Describe("basicEvent", func() {
 			Expect(e.Type()).To(Equal(Shutdown))
 		})
 	})
+
+	Describe("TypeString", func() {
+		It("Should return the right string", func() {
+			e := &basicEvent{etype: "shutdown", dtype: Shutdown, Comp: "ginkg", Ident: "node.example"}
+			Expect(e.TypeString()).To(Equal("shutdown"))
+		})
+	})
 })

--- a/event.go
+++ b/event.go
@@ -5,6 +5,7 @@ type Event interface {
 	Target() (string, error)
 	String() string
 	Type() Type
+	TypeString() string
 	SetIdentity(string)
 	Component() string
 	Identity() string

--- a/provisioned_test.go
+++ b/provisioned_test.go
@@ -12,6 +12,7 @@ var _ = Describe("ProvisionedEvent", func() {
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.dtype).To(Equal(Provisioned))
 			Expect(event.etype).To(Equal("provisioned"))
+			Expect(event.TypeString()).To(Equal("provisioned"))
 		})
 	})
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -12,6 +12,7 @@ var _ = Describe("ShutdownEvent", func() {
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.dtype).To(Equal(Shutdown))
 			Expect(event.etype).To(Equal("shutdown"))
+			Expect(event.TypeString()).To(Equal("shutdown"))
 		})
 	})
 

--- a/startup_test.go
+++ b/startup_test.go
@@ -25,6 +25,8 @@ var _ = Describe("StartupEvent", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.Type()).To(Equal(Startup))
+			Expect(event.TypeString()).To(Equal("startup"))
+
 		})
 	})
 

--- a/viewer.go
+++ b/viewer.go
@@ -68,6 +68,12 @@ func WriteEvents(ctx context.Context, opt *ViewOptions) error {
 				}
 			}
 
+			if opt.TypeFilter != "" {
+				if event.TypeString() != opt.TypeFilter {
+					continue
+				}
+			}
+
 			if opt.Debug {
 				fmt.Fprintf(opt.Output, "%s\n", string(e.Data))
 				continue


### PR DESCRIPTION
This required the event type string representation to be retrievable
from each event hence a chance to the interface for event and an
implimentation on the basic event