### PR TITLE
(#25) use io.choria.lifecycle.v1.x for message protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Event Schemas are stored in the [Choria Schemas repository](https://github.com/c
 
 ```json
 {
-    "protocol":"choria:lifecycle:startup:1",
+    "protocol":"io.choria.lifecycle.v1.startup",
     "identity":"c1.example.net",
     "version":"0.6.0",
     "timestamp":1535369537,
@@ -40,7 +40,7 @@ Event Schemas are stored in the [Choria Schemas repository](https://github.com/c
 
 ```json
 {
-    "protocol":"choria:lifecycle:shutdown:1",
+    "protocol":"io.choria.lifecycle.v1.shutdown",
     "identity":"c1.example.net",
     "component":"server",
     "timestamp":1535369536
@@ -51,7 +51,7 @@ Event Schemas are stored in the [Choria Schemas repository](https://github.com/c
 
 ```json
 {
-    "protocol":"choria:lifecycle:provisioned:1",
+    "protocol":"io.choria.lifecycle.v1.provisioned",
     "identity":"c1.example.net",
     "component":"server",
     "timestamp":1535369536
@@ -62,7 +62,7 @@ Event Schemas are stored in the [Choria Schemas repository](https://github.com/c
 
 ```json
 {
-    "protocol":"choria:lifecycle:alive:1",
+    "protocol":"io.choria.lifecycle.v1.alive",
     "identity":"c1.example.net",
     "version":"0.6.0",
     "timestamp":1535369537,

--- a/alive.go
+++ b/alive.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// StartupEvent is a choria:lifecycle:alive:1 event
+// AliveEvent is a io.choria.lifecycle.v1.alive event
 //
 // In addition to the usually required fields it requires a Version()
 // specified when producing this type of event
@@ -29,7 +29,7 @@ func init() {
 func newAliveEvent(opts ...Option) *AliveEvent {
 	event := &AliveEvent{
 		basicEvent: basicEvent{
-			Protocol:  "choria:lifecycle:alive:1",
+			Protocol:  "io.choria.lifecycle.v1.alive",
 			Timestamp: timeStamp(),
 			etype:     "alive",
 			dtype:     Alive,
@@ -55,7 +55,11 @@ func newAliveEventFromJSON(j []byte) (*AliveEvent, error) {
 		return nil, err
 	}
 
-	if event.Protocol != "choria:lifecycle:alive:1" {
+	if event.Protocol == "choria:lifecycle:alive:1" {
+		event.Protocol = "io.choria.lifecycle.v1.alive"
+	}
+
+	if event.Protocol != "io.choria.lifecycle.v1.alive" {
 		return nil, fmt.Errorf("invalid protocol '%s'", event.Protocol)
 	}
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Events", func() {
 		})
 
 		It("Should handle unknown event types", func() {
-			_, err := NewFromJSON([]byte(`{"protocol":"choria:lifecycle:unknown:1"}`))
-			Expect(err).To(MatchError("unknown protocol 'choria:lifecycle:unknown:1' received"))
+			_, err := NewFromJSON([]byte(`{"protocol":"io.choria.lifecycle.v1.unknown"}`))
+			Expect(err).To(MatchError("unknown protocol 'io.choria.lifecycle.v1.unknown' received"))
 		})
 	})
 
@@ -70,7 +70,7 @@ var _ = Describe("Events", func() {
 			Expect(err).ToNot(HaveOccurred())
 			mockTime = 1535106973
 			Expect(err).ToNot(HaveOccurred())
-			conn.EXPECT().PublishRaw("choria.lifecycle.event.startup.ginkgo", []byte(`{"protocol":"choria:lifecycle:startup:1","identity":"ginkgo.example.net","component":"ginkgo","timestamp":1535106973,"version":"1.2.3"}`))
+			conn.EXPECT().PublishRaw("choria.lifecycle.event.startup.ginkgo", []byte(`{"protocol":"io.choria.lifecycle.v1.startup","identity":"ginkgo.example.net","component":"ginkgo","timestamp":1535106973,"version":"1.2.3"}`))
 			PublishEvent(event, conn)
 		})
 	})

--- a/provisioned.go
+++ b/provisioned.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// ProvisionedEvent is a choria::lifecycle::provisioned:1 event
+// ProvisionedEvent is a io.choria.lifecycle.v1.provisioned event
 type ProvisionedEvent struct {
 	basicEvent
 }
@@ -25,7 +25,7 @@ func init() {
 func newProvisionedEvent(opts ...Option) *ProvisionedEvent {
 	event := &ProvisionedEvent{
 		basicEvent: basicEvent{
-			Protocol:  "choria:lifecycle:provisioned:1",
+			Protocol:  "io.choria.lifecycle.v1.provisioned",
 			Timestamp: timeStamp(),
 			etype:     "provisioned",
 			dtype:     Provisioned,
@@ -52,7 +52,11 @@ func newProvisionedEventFromJSON(j []byte) (*ProvisionedEvent, error) {
 		return nil, err
 	}
 
-	if event.Protocol != "choria:lifecycle:provisioned:1" {
+	if event.Protocol == "choria:lifecycle:provisioned:1" {
+		event.Protocol = "io.choria.lifecycle.v1.provisioned"
+	}
+
+	if event.Protocol != "io.choria.lifecycle.v1.provisioned" {
 		return nil, fmt.Errorf("invalid protocol '%s'", event.Protocol)
 	}
 

--- a/provisioned_test.go
+++ b/provisioned_test.go
@@ -23,7 +23,7 @@ var _ = Describe("ProvisionedEvent", func() {
 		})
 
 		It("Should parse valid events", func() {
-			event, err := newProvisionedEventFromJSON([]byte(`{"protocol":"choria:lifecycle:provisioned:1", "component":"ginkgo"}`))
+			event, err := newProvisionedEventFromJSON([]byte(`{"protocol":"io.choria.lifecycle.v1.provisioned", "component":"ginkgo"}`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.dtype).To(Equal(Provisioned))

--- a/shutdown.go
+++ b/shutdown.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// ShutdownEvent is a choria:lifecycle:shutdown:1 event
+// ShutdownEvent is a io.choria.lifecycle.v1.shutdown event
 type ShutdownEvent struct {
 	basicEvent
 }
@@ -25,7 +25,7 @@ func init() {
 func newShutdownEvent(opts ...Option) *ShutdownEvent {
 	event := &ShutdownEvent{
 		basicEvent: basicEvent{
-			Protocol:  "choria:lifecycle:shutdown:1",
+			Protocol:  "io.choria.lifecycle.v1.shutdown",
 			Timestamp: timeStamp(),
 			etype:     "shutdown",
 			dtype:     Shutdown,
@@ -51,7 +51,11 @@ func newShutdownEventFromJSON(j []byte) (*ShutdownEvent, error) {
 		return nil, err
 	}
 
-	if event.Protocol != "choria:lifecycle:shutdown:1" {
+	if event.Protocol == "choria:lifecycle:shutdown:1" {
+		event.Protocol = "io.choria.lifecycle.v1.shutdown"
+	}
+
+	if event.Protocol != "io.choria.lifecycle.v1.shutdown" {
 		return nil, fmt.Errorf("invalid protocol '%s'", event.Protocol)
 	}
 

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -23,7 +23,7 @@ var _ = Describe("ShutdownEvent", func() {
 		})
 
 		It("Should parse valid events", func() {
-			event, err := newShutdownEventFromJSON([]byte(`{"protocol":"choria:lifecycle:shutdown:1", "component":"ginkgo"}`))
+			event, err := newShutdownEventFromJSON([]byte(`{"protocol":"io.choria.lifecycle.v1.shutdown", "component":"ginkgo"}`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.dtype).To(Equal(Shutdown))

--- a/startup.go
+++ b/startup.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// StartupEvent is a choria:lifecycle:startup:1 event
+// StartupEvent is a io.choria.lifecycle.v1.startup event
 //
 // In addition to the usually required fields it requires a Version()
 // specified when producing this type of event
@@ -29,7 +29,7 @@ func init() {
 func newStartupEvent(opts ...Option) *StartupEvent {
 	event := &StartupEvent{
 		basicEvent: basicEvent{
-			Protocol:  "choria:lifecycle:startup:1",
+			Protocol:  "io.choria.lifecycle.v1.startup",
 			Timestamp: timeStamp(),
 			etype:     "startup",
 			dtype:     Startup,
@@ -55,7 +55,11 @@ func newStartupEventFromJSON(j []byte) (*StartupEvent, error) {
 		return nil, err
 	}
 
-	if event.Protocol != "choria:lifecycle:startup:1" {
+	if event.Protocol == "choria:lifecycle:startup:1" {
+		event.Protocol = "io.choria.lifecycle.v1.startup"
+	}
+
+	if event.Protocol != "io.choria.lifecycle.v1.startup" {
 		return nil, fmt.Errorf("invalid protocol '%s'", event.Protocol)
 	}
 

--- a/startup_test.go
+++ b/startup_test.go
@@ -21,7 +21,7 @@ var _ = Describe("StartupEvent", func() {
 		})
 
 		It("Should parse valid events", func() {
-			event, err := newStartupEventFromJSON([]byte(`{"protocol":"choria:lifecycle:startup:1", "component":"ginkgo"}`))
+			event, err := newStartupEventFromJSON([]byte(`{"protocol":"io.choria.lifecycle.v1.startup", "component":"ginkgo"}`))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(event.Component()).To(Equal("ginkgo"))
 			Expect(event.Type()).To(Equal(Startup))


### PR DESCRIPTION
The choria:lifecycle stuff is a bit weird and not how other projects
tend to do this so this change will be a more palatable experience,
we should probably look to move other things like generated stream
messages etc to this format too.

Inevitably a chance of breaking things if old code received new events
however code using the latest lifecycle library will support both formats